### PR TITLE
support pyramid 1.10+ and python 3.7+ only (lazy)

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,4 +1,4 @@
 [pep8]
 ignore = E123,E127
-# E123: closnig bracket must match indent of starting bracket
+# E123: closing bracket must match indent of starting bracket
 # E127 continuation line over-indented for visual indent

--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -8,11 +8,8 @@ function handle_exit {
 }
 
 echo '====== Running tests ========='
-bin/nosetests; handle_exit
-
-echo '====== Running PyFlakes ======'
-bin/python setup.py flakes; handle_exit
+nosetests src/pyramid_marrowmailer; handle_exit
 
 echo '====== Running pep8 =========='
-bin/pep8 src/pyramid_marrowmailer; handle_exit
-bin/pep8 *.py; handle_exit
+pycodestyle src/pyramid_marrowmailer; handle_exit
+pycodestyle ./*.py; handle_exit

--- a/setup.py
+++ b/setup.py
@@ -1,51 +1,65 @@
 # -*- coding: utf-8 -*-
 
 import os
+from os.path import join
+import re
 
 from setuptools import setup
 from setuptools import find_packages
 
-from codecs import open # To use a consistent encoding
+from codecs import open  # To use a consistent encoding
 
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames), encoding='utf-8').read()
+    return open(os.path.join(os.path.dirname(__file__), *rnames),
+                encoding='utf-8').read()
 
 
-setup(name='pyramid_marrowmailer',
-      version='0.3.dev0',
-      description='Pyramid integration package for marrow.mailer,'
-        ' formerly known as TurboMail',
-      long_description=read('README.rst') +
-                       read('HISTORY.rst'),
-      classifiers=[
-          "Programming Language :: Python",
-          "Framework :: Pyramid",
-      ],
-      keywords='web wsgi pylons pyramid',
-      author='',
-      author_email='domen@dev.si',
-      url='https://github.com/iElectric/pyramid_marrowmailer',
-      license='BSD',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      install_requires=[
-          'pyramid',
-          'pyramid_tm',
-          'marrow.mailer',
-          'setuptools',
-          'transaction',
-      ],
-      extras_require={
-          'test': [
-              'nose',
-              'coverage',
-              'setuptools-flakes',
-              'pep8',
-          ],
-      },
-      entry_points="""
+def find_version(file_path):
+    """copied from pyelasticsearch"""
+    version_file = read(file_path)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError('Unable to find version string.')
+
+
+setup(
+    name='pyramid_marrowmailer',
+    version=find_version(join('src', 'pyramid_marrowmailer', '__init__.py')),
+    description='Pyramid integration package for marrow.mailer,'
+                ' formerly known as TurboMail',
+    long_description=read('README.rst') + read('HISTORY.rst'),
+    classifiers=[
+        "Programming Language :: Python",
+        "Framework :: Pyramid",
+    ],
+    keywords='web wsgi pylons pyramid',
+    author='',
+    author_email='domen@dev.si',
+    url='https://github.com/iElectric/pyramid_marrowmailer',
+    license='BSD',
+    packages=find_packages('src'),
+    package_dir={'': 'src'},
+    python_requires='>=3.7',
+    install_requires=[
+        'pyramid>=1.10',
+        'pyramid_tm>=2.4',
+        'marrow.mailer>=4.0',
+        'setuptools',
+        'transaction>=3.0',
+    ],
+    extras_require={
+        'test': [
+            'nose',
+            'coverage',
+            'setuptools-flakes',
+            'pep8',
+        ],
+    },
+    entry_points="""
       """,
-      include_package_data=True,
-      zip_safe=False,
-      )
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-from os.path import join
-import re
 
 from setuptools import setup
 from setuptools import find_packages
@@ -15,19 +13,9 @@ def read(*rnames):
                 encoding='utf-8').read()
 
 
-def find_version(file_path):
-    """copied from pyelasticsearch"""
-    version_file = read(file_path)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError('Unable to find version string.')
-
-
 setup(
     name='pyramid_marrowmailer',
-    version=find_version(join('src', 'pyramid_marrowmailer', '__init__.py')),
+    version='0.4',
     description='Pyramid integration package for marrow.mailer,'
                 ' formerly known as TurboMail',
     long_description=read('README.rst') + read('HISTORY.rst'),

--- a/src/pyramid_marrowmailer/__init__.py
+++ b/src/pyramid_marrowmailer/__init__.py
@@ -6,9 +6,6 @@ from pyramid.settings import asbool
 from zope.interface import Interface
 
 
-__version__ = '0.4.0'
-
-
 class IMarrowMailer(Interface):
     pass
 

--- a/src/pyramid_marrowmailer/__init__.py
+++ b/src/pyramid_marrowmailer/__init__.py
@@ -6,6 +6,9 @@ from pyramid.settings import asbool
 from zope.interface import Interface
 
 
+__version__ = '0.4.0'
+
+
 class IMarrowMailer(Interface):
     pass
 
@@ -88,7 +91,7 @@ def includeme(config):
     mailer.start()
 
     config.registry.registerUtility(mailer, IMarrowMailer)
-    config.set_request_property(get_mailer, "mailer", reify=True)
+    config.add_request_method(get_mailer, "mailer", reify=True)
 
     # shutdown mailer when process stops
     atexit.register(lambda: mailer.stop())


### PR DESCRIPTION
support pyramid 1.10+ and python 3.7+ only (lazy)
- ./pre-commit-check.sh works now (requires pip install pycodestyle)